### PR TITLE
misplaced const declaration

### DIFF
--- a/DFRobotIRPosition.h
+++ b/DFRobotIRPosition.h
@@ -17,10 +17,10 @@
 #ifndef DFRobotIRPosition_cpp
   #define DFRobotIRPosition_cpp
 
+const int IRAddress = 0xB0 >> 1; ///< IIC address of the sensor
+
 class DFRobotIRPosition {
 
-  const int IRAddress = 0xB0 >> 1; ///< IIC address of the sensor
-  
   /*!
    *  @brief position data structure from IIC sensor
    */


### PR DESCRIPTION
I suggest to move up const decalration outside class declaration to be able to compile with arduino 1.6

regards
